### PR TITLE
ci: Update GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,19 +11,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Node.js 22
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: 'yarn'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Install Yarn 4.9
+      - name: Install Yarn 4
         run: |
           corepack enable
-          yarn set version 4.9.0
+          yarn set version 4
 
       - name: Install dependencies
         run: yarn install --immutable


### PR DESCRIPTION
Update GitHub Actions to use latest versions of checkout and setup-node